### PR TITLE
Resolve non-local domains in CoreDNS config

### DIFF
--- a/deployments/coredns.yaml
+++ b/deployments/coredns.yaml
@@ -60,6 +60,7 @@ data:
           pods insecure
           fallthrough in-addr.arpa ip6.arpa
         }
+        forward . 8.8.8.8 8.8.4.4
         prometheus :9153
         cache 30
         loop


### PR DESCRIPTION
Currently CoreDNS only resolves domains in `cluster.local` domain. Added a `forward` clause to mitigate this.