### PR TITLE
Update 06-data-encryption-keys.md

### DIFF
--- a/docs/06-data-encryption-keys.md
+++ b/docs/06-data-encryption-keys.md
@@ -36,7 +36,7 @@ Copy the `encryption-config.yaml` encryption config file to each controller inst
 
 ```
 for instance in controller-0 controller-1 controller-2; do
-  gcloud compute scp encryption-config.yaml ${instance}:~/
+  gcloud compute scp encryption-config.yaml ${instance}:
 done
 ```
 


### PR DESCRIPTION
Having ~/ after ${instance}: would return pscp: remote filespec ~/: not a directory error. Removing the ~/ section resolves the issue.