### PR TITLE
Update 05-kubernetes-configuration-files.md

### DIFF
--- a/docs/05-kubernetes-configuration-files.md
+++ b/docs/05-kubernetes-configuration-files.md
@@ -199,7 +199,7 @@ Copy the appropriate `kubelet` and `kube-proxy` kubeconfig files to each worker 
 
 ```
 for instance in worker-0 worker-1 worker-2; do
-  gcloud compute scp ${instance}.kubeconfig kube-proxy.kubeconfig ${instance}:~/
+  gcloud compute scp ${instance}.kubeconfig kube-proxy.kubeconfig ${instance}:
 done
 ```
 
@@ -207,7 +207,7 @@ Copy the appropriate `kube-controller-manager` and `kube-scheduler` kubeconfig f
 
 ```
 for instance in controller-0 controller-1 controller-2; do
-  gcloud compute scp admin.kubeconfig kube-controller-manager.kubeconfig kube-scheduler.kubeconfig ${instance}:~/
+  gcloud compute scp admin.kubeconfig kube-controller-manager.kubeconfig kube-scheduler.kubeconfig ${instance}:
 done
 ```
 


### PR DESCRIPTION
Having ~/ after ${instance}: would return pscp: remote filespec ~/: not a directory error. Removing the ~/ section resolves the issue.