### PR TITLE
Update 04-certificate-authority.md

### DIFF
--- a/docs/04-certificate-authority.md
+++ b/docs/04-certificate-authority.md
@@ -396,7 +396,7 @@ Copy the appropriate certificates and private keys to each worker instance:
 
 ```
 for instance in worker-0 worker-1 worker-2; do
-  gcloud compute scp ca.pem ${instance}-key.pem ${instance}.pem ${instance}:~/
+  gcloud compute scp ca.pem ${instance}-key.pem ${instance}.pem ${instance}:
 done
 ```
 
@@ -405,7 +405,7 @@ Copy the appropriate certificates and private keys to each controller instance:
 ```
 for instance in controller-0 controller-1 controller-2; do
   gcloud compute scp ca.pem ca-key.pem kubernetes-key.pem kubernetes.pem \
-    service-account-key.pem service-account.pem ${instance}:~/
+    service-account-key.pem service-account.pem ${instance}:
 done
 ```
 


### PR DESCRIPTION
Having ~/ after ${instance}: would return pscp: remote filespec ~/: not a directory error. Removing the ~/ section resolves the issue.